### PR TITLE
feat(weights): migrate rules_score->rules with backward compatibility

### DIFF
--- a/scripts/migrate_weights_keys.py
+++ b/scripts/migrate_weights_keys.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+权重键名迁移脚本 - 将历史别名映射为标准键名
+"""
+
+import json, sys, pathlib
+
+ALIASES = {
+    "rules_score": "rules",
+    # 如有其它历史别名，继续在此登记
+}
+ALLOWED = {"logic_rigor","question_quality","reasoning_completeness","natural_interaction","rules"}
+
+def load(path):
+    d = json.load(open(path))
+    # 容错：有人把权重包在 "weights" 里
+    if isinstance(d, dict) and "weights" in d and isinstance(d["weights"], dict):
+        d = d["weights"]
+    return d
+
+def normalize(w):
+    total = sum(max(0.0, float(v)) for v in w.values())
+    if total == 0: raise ValueError("all-zero weights")
+    return {k: max(0.0, float(v))/total for k,v in w.items()}
+
+def migrate(w):
+    ww = {}
+    for k,v in w.items():
+        k2 = ALIASES.get(k, k)
+        ww[k2] = ww.get(k2, 0.0) + float(v)
+    # 仅保留允许字段
+    ww = {k:v for k,v in ww.items() if k in ALLOWED}
+    return normalize(ww)
+
+def main(p="configs/weights.json", out="configs/weights.json"):
+    w0 = load(p)
+    w1 = migrate(w0)
+    json.dump(w1, open(out, "w"), indent=2, ensure_ascii=False)
+    pathlib.Path("artifacts").mkdir(exist_ok=True, parents=True)
+    json.dump({"before": w0, "after": w1}, open("artifacts/weights.migration.audit.json","w"), indent=2, ensure_ascii=False)
+    print("OK ->", out)
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])

--- a/src/evaluation/exceptions.py
+++ b/src/evaluation/exceptions.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""
+评估模块异常定义
+"""
+
+class WeightsSchemaError(ValueError):
+    """权重模式错误"""
+    pass
+
+class ScoringChannelError(RuntimeError):
+    """评分通道错误"""
+    pass
+
+class DataAuditError(ValueError):
+    """数据审计错误"""
+    pass

--- a/src/evaluation/weights_loader.py
+++ b/src/evaluation/weights_loader.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+权重加载器 - 向后兼容 + 严格校验
+"""
+
+import json, warnings
+from .exceptions import WeightsSchemaError
+
+ALIASES = {"rules_score":"rules"}
+ALLOWED = {"logic_rigor","question_quality","reasoning_completeness","natural_interaction","rules"}
+
+def load_weights(path="configs/weights.json"):
+    d = json.load(open(path))
+    if "weights" in d and isinstance(d["weights"], dict):
+        d = d["weights"]
+    # alias 映射 + 合并
+    fixed = {}
+    for k,v in d.items():
+        k2 = ALIASES.get(k, k)
+        if k != k2: warnings.warn(f"weights key '{k}' is deprecated, use '{k2}'", DeprecationWarning)
+        if k2 in ALLOWED:
+            fixed[k2] = fixed.get(k2, 0.0) + float(v)
+    # 归一化 + 非负
+    s = sum(max(0.0,float(x)) for x in fixed.values())
+    if s <= 0: raise WeightsSchemaError("weights sum <= 0")
+    fixed = {k: max(0.0,float(v))/s for k,v in fixed.items()}
+    # 全字段存在性（可选：允许缺失则按0处理）
+    missing = ALLOWED - fixed.keys()
+    if missing: raise WeightsSchemaError(f"missing keys: {sorted(missing)}")
+    return fixed

--- a/tests/test_weights_schema.py
+++ b/tests/test_weights_schema.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+权重模式单测
+"""
+
+import json, os
+import pytest
+from src.evaluation.weights_loader import load_weights
+from src.evaluation.exceptions import WeightsSchemaError
+
+def write(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path,"w") as f: json.dump(data, f)
+
+def test_alias_and_normalization(tmp_path):
+    p = tmp_path/"weights.json"
+    write(p, {"weights":{"rules_score":0.3,"logic_rigor":0.3,"question_quality":0.2,"reasoning_completeness":0.1,"natural_interaction":0.1}})
+    w = load_weights(str(p))
+    assert abs(sum(w.values())-1.0)<1e-9
+    assert "rules" in w and w["rules"]>0
+
+def test_missing_keys_raises(tmp_path):
+    p = tmp_path/"weights.json"
+    write(p, {"rules":1.0})
+    with pytest.raises(WeightsSchemaError):
+        load_weights(str(p))
+
+def test_all_zero_raises(tmp_path):
+    p = tmp_path/"weights.json"
+    write(p, {"logic_rigor":0.0,"question_quality":0.0,"reasoning_completeness":0.0,"natural_interaction":0.0,"rules":0.0})
+    with pytest.raises(WeightsSchemaError):
+        load_weights(str(p))
+
+def test_deprecation_warning(tmp_path):
+    import warnings
+    p = tmp_path/"weights.json"
+    write(p, {"rules_score":0.3,"logic_rigor":0.3,"question_quality":0.2,"reasoning_completeness":0.1,"natural_interaction":0.1})
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warnings.filterwarnings("ignore", category=ResourceWarning)  # Ignore resource warnings
+        load_weights(str(p))
+        # Find the deprecation warning
+        deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
+        assert len(deprecation_warnings) > 0
+        assert "deprecated" in str(deprecation_warnings[0].message)


### PR DESCRIPTION
- Add weights_loader.py with alias mapping and validation
- Add migrate_weights_keys.py script for one-time migration
- Update weight_calib.py to use new loader
- Add comprehensive tests for weights schema
- Fix reward system to use new weights format
- Generate migration audit trail in artifacts/

BREAKING: configs/weights.json format changed from {'weights':{}} to direct weights object
COMPAT: Backward compatible loader with deprecation warnings