### PR TITLE
hotfix/decoupling-final2: purge root, fix README, enforce root guard

### DIFF
--- a/.github/workflows/redlines.yml
+++ b/.github/workflows/redlines.yml
@@ -74,13 +74,15 @@ jobs:
             exit 1
           fi
 
-          # 检查是否还有根目录残留
-          if [ -f "gemini_integration.py" ] || [ -f "gemini_cache.sqlite" ]; then
-            echo "❌ 发现根目录残留文件"
-            ls -la | grep gemini || true
+      - name: Root directory must be clean
+        run: |
+          echo "🔍 检查根目录是否干净..."
+          if ls -1 | egrep -q "^(gemini_cache\.sqlite|gemini_integration\.py)$"; then
+            echo "❌ 根目录被Gemini文件污染"
+            ls -la | egrep "gemini_cache\.sqlite|gemini_integration\.py" || true
             exit 1
           else
-            echo "✅ 根目录无Gemini残留"
+            echo "✅ 根目录干净，无Gemini残留"
           fi
 
       - name: Validate quality artifacts


### PR DESCRIPTION
- Root directory purge: ensure no Gemini files in root (gemini_cache.sqlite, gemini_integration.py)
- README correction: update all paths to integrations/gemini/gemini_integration.py
- CI enhancement: add explicit 'Root directory must be clean' guard step
- Verification: root clean ✅, sidecar isolated ✅, README updated ✅

Self-check results:
1. ls -la | egrep 'gemini_cache\.sqlite|gemini_integration\.py' || echo 'no root gemini files ✅' → no root gemini files ✅

2. test -f integrations/gemini/gemini_integration.py && echo 'sidecar present ✅' → sidecar present ✅

3. grep -n 'python integrations/gemini/gemini_integration.py' README.md → 100:python integrations/gemini/gemini_integration.py